### PR TITLE
Handle exceptions in ReflectionProperty::getValue()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
             "src/"
         ]
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests/"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0.x-dev"

--- a/src/Enumerator.php
+++ b/src/Enumerator.php
@@ -69,7 +69,13 @@ class Enumerator
             foreach ($reflector->getProperties() as $attribute) {
                 $attribute->setAccessible(true);
 
-                $value = $attribute->getValue($variable);
+                try {
+                    $value = $attribute->getValue($variable);
+                } catch (\Throwable $e) {
+                    continue;
+                } catch (\Exception $e) {
+                    continue;
+                }
 
                 if (!is_array($value) && !is_object($value)) {
                     continue;

--- a/tests/EnumeratorTest.php
+++ b/tests/EnumeratorTest.php
@@ -10,6 +10,8 @@
 
 namespace SebastianBergmann\ObjectEnumerator;
 
+use SebastianBergmann\ObjectEnumerator\Fixtures\ExceptionThrower;
+
 /**
  * @covers SebastianBergmann\ObjectEnumerator\Enumerator
  */
@@ -109,6 +111,15 @@ class EnumeratorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $objects);
         $this->assertSame($a, $objects[0]);
         $this->assertSame($b, $objects[1]);
+    }
+
+    public function testEnumeratesClassThatThrowsException()
+    {
+        $thrower = new ExceptionThrower();
+
+        $objects = $this->enumerator->enumerate($thrower);
+
+        $this->assertSame($thrower, $objects[0]);
     }
 
     public function testExceptionIsRaisedForInvalidArgument()

--- a/tests/Fixtures/ExceptionThrower.php
+++ b/tests/Fixtures/ExceptionThrower.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * This file is part of Object Enumerator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\ObjectEnumerator\Fixtures;
+
+use RuntimeException;
+
+class ExceptionThrower
+{
+    private $property;
+
+    public function __construct()
+    {
+        unset($this->property);
+    }
+
+    public function __get($property)
+    {
+        throw new RuntimeException;
+    }
+}


### PR DESCRIPTION
There is an edge case where `ReflectionProperty::getValue()` can throw exceptions: when a class unsets a declared property the `__get` magic method of said object is called. One library that uses this trick is [ocramius/proxy-manager](https://github.com/Ocramius/ProxyManager) (see [related issue](https://github.com/Ocramius/ProxyManager/issues/298)).
The attached PR just catches all exceptions and ignores them.